### PR TITLE
Accept executable function as arg to Maybe.fold

### DIFF
--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -454,8 +454,9 @@
         },
         fold: function (defaultValue) {
             var self = this
+            var value = typeof defaultValue === 'function'? defaultValue() : defaultValue
             return function (fn) {
-                return self.isSome() ? fn(self.val) : defaultValue
+                return self.isSome() ? fn(self.val) : value
             }
         },
         filter: function(fn) {

--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -454,9 +454,10 @@
         },
         fold: function (defaultValue) {
             var self = this
-            var value = typeof defaultValue === 'function'? defaultValue() : defaultValue
+            var thunk = function(){ return defaultValue}
+            var defn = typeof defaultValue === 'function'? defaultValue : thunk
             return function (fn) {
-                return self.isSome() ? fn(self.val) : value
+                return self.isSome() ? fn(self.val) : defn()
             }
         },
         filter: function(fn) {

--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -454,11 +454,12 @@
         },
         fold: function (defaultValue) {
             var self = this
-            var thunk = function(){ return defaultValue}
-            var defn = typeof defaultValue === 'function'? defaultValue : thunk
             return function (fn) {
-                return self.isSome() ? fn(self.val) : defn()
+                return self.isSome() ? fn(self.val) : defaultValue
             }
+        },
+        cata: function (none, some) {
+            return this.isSome() ? some(this.val) : none()
         },
         filter: function(fn) {
           var self = this

--- a/src/test/javascript/maybe_spec.js
+++ b/src/test/javascript/maybe_spec.js
@@ -64,6 +64,10 @@ describe('A Maybe', function () {
         it('will return a some on a successful filter', function() {
             expect(someString.filter(function(a) {return a === "abcd"})).toBe(someString)
         })
+        it('will run the some side of cata', function(){
+            expect(someString.cata(function() {return 'efg'}, 
+                function(val){ return 'hij'})).toBe('hij')
+        })
     })
 
     describe('without a value', function () {
@@ -105,6 +109,10 @@ describe('A Maybe', function () {
         })
         it('will always return a None on filter', function() {
           expect(none.filter(function(a){return true})).toBeNoneMaybe()
+        })
+        it('will run the none side of cata', function(){
+            expect(none.cata(function() {return 'efg'}, 
+                function(val){ return 'hij'})).toBe('efg')
         })
     })
 


### PR DESCRIPTION
Currently `Maybe.fold` accepts a default value.  This change permits a function to be passed as the argument instead of a value.  If the underlying `Maybe` is `None`, the functional arg will be lazily evaluated.

This change is theoretically backwards incompatible, but I'm not sure that the edge case of `fold` being passed a function-as-value is very common.