### PR TITLE
Add List.ap, Free.ap and NonEmptyList.ap

### DIFF
--- a/src/main/javascript/monet.js
+++ b/src/main/javascript/monet.js
@@ -147,6 +147,14 @@
       })
     }
 
+    var listAp = function(list1, list2) {
+        return list1.bind(function(x) {
+          return list2.map(function(f) {
+                return f(x)
+            })
+        })
+    }
+
     var cons = function (head, tail) {
         return tail.cons(head)
     }
@@ -248,6 +256,9 @@
         },
         tails: function () {
             return this.isNil ? List(Nil, Nil) : this.tail().tails().cons(this)
+        },
+        ap: function(list) {
+            return listAp(this, list)
         },
         isNEL: falseFunction
     }
@@ -380,6 +391,7 @@
     NEL.prototype.extract = NEL.prototype.copure = NEL.prototype.head
     NEL.prototype.cojoin = NEL.prototype.tails
     NEL.prototype.coflatMap = NEL.prototype.mapTails = NEL.prototype.cobind
+    NEL.prototype.ap = List.prototype.ap
 
 
     /* Maybe Monad */
@@ -809,6 +821,14 @@
                         })) :
                 fn(this.val)
         },
+        ap: function(ff) {
+          return this.bind(function(x) {
+            return ff.map(function(f) {
+              return f(x)
+            })
+          })
+        },
+
         resume: function () {
             return this.isSuspend ? Left(this.functor) : Right(this.val)
         },

--- a/src/test/javascript/monad_laws.js
+++ b/src/test/javascript/monad_laws.js
@@ -27,6 +27,15 @@ describe('The Monad', function () {
         expect(reduction(a)).toBe(reduction(b))
 
       })
+
+      it("must also be applicative", function() {
+        var m = monad.of(123)
+        var f = function(t) { return 2*t }
+        var mf = monad.of(f)
+        var a = m.ap(mf)
+        var b = m.bind(function(t) { return m.unit(f(t)) })
+        expect(reduction(a)).toBe(reduction(b))
+      })
     }
 
     describe('Maybe', function() {


### PR DESCRIPTION
Hello!

I noticed that not all the monads have the `ap` method, while the documentation says they should. I added the missing `List.ap`, `Free.ap` and `NonEmptyList.ap` here. I also added the test in `monad_laws` - it's not exactly a monad law, but this is the test suite that runs the tests for all the monads, so It's super convenient...

Also, we're working on TypeScript typings for monet.js, so this is the first step towards that :)