### PR TITLE
Add .equals method for container-like monads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,6 @@
+interface IEquals<A> {
+  equals(a: A): boolean
+}
 /* The (covariant) functor typeclass */
 interface Functor<T> {
     map<V>(fn: (val: T) => V): Functor<V>;
@@ -77,7 +80,7 @@ export var Identity: IIdentityStatic;
  * Maybe
  */
 
-export interface Maybe<T> extends IMonad<T> {
+export interface Maybe<T> extends IMonad<T>, IEquals<Maybe<T>>{
     /* Inherited from Monad: */
     bind<V>(fn: (val: T) => Maybe<V>): Maybe<V>;
     flatMap<V>(fn: (val: T) => Maybe<V>): Maybe<V>;
@@ -140,7 +143,7 @@ export var Maybe: IMaybeStatic;
  * Either
  */
 
-export interface Either<E, T> extends IMonad<T> {
+export interface Either<E, T> extends IMonad<T>, IEquals<Either<E, T>>{
     /* Inherited from Monad: */
     bind<V>(fn: (val: T) => Either<E, V>): Either<E, V>;
     flatMap<V>(fn: (val: T) => Either<E, V>): Either<E, V>;
@@ -196,7 +199,7 @@ interface IValidationAcc extends Function {
     (): IValidationAcc;
 }
 
-export interface Validation<E, T> extends IMonad<T> {
+export interface Validation<E, T> extends IMonad<T>, IEquals<Validation<E, T>>{
     /* Inherited from Monad: */
     bind<V>(fn: (val: T) => Validation<E, V>): Validation<E, V>;
     flatMap<V>(fn: (val: T) => Validation<E, V>): Validation<E, V>;
@@ -253,7 +256,7 @@ export var Fail: IFailStatic;
  * List
  */
 
-export interface List<T> extends IMonad<T> {
+export interface List<T> extends IMonad<T>, IEquals<List<T>> {
     /* Inherited from Monad: */
     bind<V>(fn: (val: T) => List<V>): List<V>;
     flatMap<V>(fn: (val: T) => List<V>): List<V>;
@@ -323,7 +326,7 @@ export var Nil: Nil;
  * NEL
  */
 
-export interface NEL<T> extends IMonad<T> {
+export interface NEL<T> extends IMonad<T>, IEquals<NEL<T>> {
     /* Inherited from Monad: */
     bind<V>(fn: (val: T) => NEL<V>): NEL<V>;
     flatMap<V>(fn: (val: T) => NEL<V>): NEL<V>;

--- a/test/either-spec.js
+++ b/test/either-spec.js
@@ -81,6 +81,14 @@ describe('An Either', function () {
         it('can be converted to Validation.Success', function() {
           expect(rightString.toValidation().success()).not.toBeUndefined()
         })
+        it('equals to Right with the same value', function() {
+          expect(rightString.equals(Either.Right('abcd'))).toBeTruthy()
+          expect(Right(Just(2)).equals(Right(Just(2)))).toBeTruthy()
+        })
+        it('does not equal to Rights with different values or Lefts', function() {
+          expect(rightString.equals(Either.Left('abcd'))).toBeFalsy()
+          expect(rightString.equals(Either.Right('x'))).toBeFalsy()
+        })
     })
 
     var leftString = Either.Left("error dude")
@@ -143,6 +151,14 @@ describe('An Either', function () {
         })
         it('can be converted to Validation.Fail', function() {
           expect(leftString.toValidation().fail()).not.toBeUndefined()
+        })
+        it('equals to Left with the same value', function() {
+          expect(leftString.equals(Either.Left('error dude'))).toBeTruthy()
+          expect(Left(Just(2)).equals(Left(Just(2)))).toBeTruthy()
+        })
+        it('does not equal to Rights with different values or Lefts', function() {
+          expect(leftString.equals(Either.Left('x'))).toBeFalsy()
+          expect(leftString.equals(Either.Right('error dude'))).toBeFalsy()
         })
 
     })

--- a/test/list-spec.js
+++ b/test/list-spec.js
@@ -26,13 +26,13 @@ describe("An immutable list", function () {
     it("will return all the possible tails on tails()", function () {
         expect(list.tails().map(function (m) {
             return m.toArray()
-        }).toArray()).toEqual([
-                [ 1, 2, 3, 4 ],
-                [ 2, 3, 4 ],
-                [ 3, 4 ],
-                [ 4 ],
-                [ ]
-            ])
+        }).equals([
+            [ 1, 2, 3, 4 ],
+            [ 2, 3, 4 ],
+            [ 3, 4 ],
+            [ 4 ],
+            [ ]
+        ].list())).toBeTruthy()
     })
 
 
@@ -41,7 +41,7 @@ describe("An immutable list", function () {
     })
 
     it("can be created from an Array", function () {
-        expect([1, 2, 3, 4].list()).toEqual(list)
+        expect([1, 2, 3, 4].list().equals(list)).toBeTruthy()
     })
 
     it("can be mapped", function () {

--- a/test/maybe-spec.js
+++ b/test/maybe-spec.js
@@ -74,6 +74,10 @@ describe('A Maybe', function () {
             expect(someString.cata(function() {return 'efg'}, 
                 function(val){ return 'hij'})).toBe('hij')
         })
+        it('will compare for equality', function() {
+          expect(someString.equals(Some('abcd'))).toBeTruthy()
+          expect(someString.equals(None())).toBeFalsy()
+        })
     })
 
     describe('without a value', function () {
@@ -119,6 +123,11 @@ describe('A Maybe', function () {
         it('will run the none side of cata', function(){
             expect(none.cata(function() {return 'efg'}, 
                 function(val){ return 'hij'})).toBe('efg')
+        })
+
+        it('will compare for equality', function() {
+          expect(none.equals(Maybe.None())).toBeTruthy()
+          expect(none.equals(Maybe.Just(1))).toBeFalsy()
         })
     })
 

--- a/test/monad-laws-spec.js
+++ b/test/monad-laws-spec.js
@@ -41,7 +41,7 @@ describe('The Monad', function () {
         var mf = monad.of(f)
         var a = m.ap(mf)
         var b = m.bind(function(t) { return m.unit(f(t)) })
-        expect(reduction(a)).toBe(reduction(b))
+        expect(equals(a, b)).toBeTruthy()
       })
     }
 

--- a/test/monad-laws-spec.js
+++ b/test/monad-laws-spec.js
@@ -1,22 +1,29 @@
 describe('The Monad', function () {
 
-    var test = function(monad, reduction) {
+    var test = function(monad) {
+      var equals = function(a, b) {
+        if (a.equals) {
+          return a.equals(b);
+        }
+        return a.run() === b.run()
+      }
+
       var fa = function (x) {
         return monad.of(x + 1)
       }
 
       it("must obey left identity", function() {
 
-        var f = reduction(monad.of(123).bind(fa))
-        var fapply = reduction(fa(123))
-        expect(f).toBe(fapply)
+        var f = monad.of(123).bind(fa)
+        var fapply = fa(123)
+        expect(equals(f, fapply)).toBeTruthy()
       })
 
       it("must obey right identity", function() {
         var m = monad.of(123)
         var m1 = m.bind(function (x) { return monad.of(x)})
 
-        expect(reduction(m)).toBe(reduction(m1))
+        expect(equals(m, m1)).toBeTruthy()
 
       })
 
@@ -24,7 +31,7 @@ describe('The Monad', function () {
         var m = monad.of(123)
         var a = (m.bind(function(x) { return monad.of(x*2)})).bind(fa)
         var b = (m.bind(function(x) { return monad.of(x*2).bind(fa)}))
-        expect(reduction(a)).toBe(reduction(b))
+        expect(equals(a, b)).toBeTruthy()
 
       })
 
@@ -39,34 +46,34 @@ describe('The Monad', function () {
     }
 
     describe('Maybe', function() {
-      test(Maybe, function(m) {return m.some()})
+      test(Maybe)
     })
 
     describe('Either', function() {
-      test(Either, function(m) {return m.right()})
+      test(Either)
     })
 
     describe('IO', function() {
-      test(IO, function(m) {return m.run()})
+      test(IO)
     })
     describe('Reader', function() {
-     test(Reader, function (m) {return m.run()})
+     test(Reader)
     })
 
     describe('List', function() {
-      test(List, function(m) {return m.head()})
+      test(List)
     })
 
     describe('NonEmptyList', function() {
-      test(NEL, function(m) {return m.head()})
+      test(NEL)
     })
 
     describe('Free', function() {
-      test(Free, function(m) {return m.run()})
+      test(Free)
     })
 
     describe('Validation', function() {
-      test(Validation, function(m) {return m.success()})
+      test(Validation)
     })
 
 })

--- a/test/typings/either-spec.ts
+++ b/test/typings/either-spec.ts
@@ -43,6 +43,7 @@ function getMessage(msg: IMessage) {
 const wrapped = getMessage({type: 'MESSAGE', payload: 'Hello World'});
 
 console.assert(!(wrapped.isRight() === wrapped.isLeft()));
+console.assert(wrapped.equals(Right<string, IMessage>({type: 'MESSAGE', payload: 'Hello World'})))
 
 const wrappedGreeting: Either<string, string> = wrapped.bind(v => v.payload ?
     Right<string, string>(v.payload) :

--- a/test/typings/maybe-spec.ts
+++ b/test/typings/maybe-spec.ts
@@ -53,6 +53,7 @@ const wrapped = getMessage({type: 'MESSAGE', payload: 'Hello World'});
 console.assert(wrapped.isSome() === wrapped.isJust());
 console.assert(wrapped.isNone() === wrapped.isNothing());
 console.assert(!(wrapped.isNone() === wrapped.isJust()));
+console.assert(wrapped.equals(Some({type: 'MESSAGE', payload: 'Hello World'})))
 
 const wrappedGreeting: Maybe<string> = wrapped.bind(v => Maybe.fromNull(v.payload));
 


### PR DESCRIPTION
This is the same PR as #47, but against `develop` instead of `master`. Original description:

Hi,
this PR adds a possibility to compare monadic values using `a.equals(b)` method. I assumed the following:
 * the `.equals` method is provided only for wrapper-like monads; it would make no sense on `Reader` or `IO`.
 * if the wrapped values have `.equals` method, is is used to perform deep comparison; otherwise, the values are compared with `===`. This approach makes it possible to compare nested monads and provides a way for users to specify custom comparisons for their data types.
 * `List` and `NEL` with the same values are equal.

Cheers,
Wojtek