### PR TITLE
Add .inspect() and .toString() (Fixes #60)

### DIFF
--- a/src/monet.js
+++ b/src/monet.js
@@ -831,6 +831,15 @@
         },
         toValidation: function () {
             return this.isRight() ? Success(this.value) : Fail(this.value)
+        },
+        toString: function () {
+            return this.cata(
+                function(left) { return 'Left(' + left + ')' },
+                function(right) { return 'Right(' + right + ')' }
+            )
+        },
+        inspect: function() {
+            return this.toString()
         }
     }
 

--- a/src/monet.js
+++ b/src/monet.js
@@ -560,6 +560,12 @@
             return self.flatMap(function (a) {
                 return fn(a) ? self : None()
             })
+        },
+        toString: function() {
+            return this.isSome() ? 'Just(' + this.val + ')' : 'Nothing'
+        },
+        inspect: function() {
+            return this.toString()
         }
     };
 

--- a/src/monet.js
+++ b/src/monet.js
@@ -327,7 +327,13 @@
         ap: function (list) {
             return listAp(this, list)
         },
-        isNEL: falseFunction
+        isNEL: falseFunction,
+        toString: function () {
+            return this.isNil ? 'Nil' : 'List(' + this.toArray().join(', ') + ')'
+        },
+        inspect: function () {
+            return this.toString()
+        }
     }
 
     List.fn.init.prototype = List.fn;
@@ -1004,6 +1010,12 @@
         },
         equals: function (other) {
             return (isFunction(other.get) && equals(this.get())(other.get()))
+        },
+        toString: function () {
+            return 'Identity(' + this.val + ')'
+        },
+        inspect: function () {
+            return this.toString()
         }
     }
 

--- a/src/monet.js
+++ b/src/monet.js
@@ -457,7 +457,13 @@
         size: function () {
             return this.size_
         },
-        isNEL: trueFunction
+        isNEL: trueFunction,
+        toString: function () {
+          return 'NEL(' + this.toArray().join(', ') + ')'
+        },
+        inspect: function () {
+          return this.toString()
+        }
     }
 
     NEL.fromList = function (list) {

--- a/src/monet.js
+++ b/src/monet.js
@@ -660,6 +660,12 @@
         },
         toEither: function () {
             return (this.isSuccess() ? Right : Left)(this.val)
+        },
+        toString: function () {
+            return (this.isSuccess() ? 'Success(' : 'Fail(') + this.val + ')'
+        },
+        inspect: function () {
+          return this.toString()
         }
     };
 

--- a/test/either-spec.js
+++ b/test/either-spec.js
@@ -89,6 +89,9 @@ describe('An Either', function () {
           expect(rightString.equals(Either.Left('abcd'))).toBeFalsy()
           expect(rightString.equals(Either.Right('x'))).toBeFalsy()
         })
+        it('renders as Right(value)', function() {
+          expect(rightString.toString()).toBe('Right(abcd)')
+        })
     })
 
     var leftString = Either.Left("error dude")
@@ -159,6 +162,9 @@ describe('An Either', function () {
         it('does not equal to Rights with different values or Lefts', function() {
           expect(leftString.equals(Either.Left('x'))).toBeFalsy()
           expect(leftString.equals(Either.Right('error dude'))).toBeFalsy()
+        })
+        it('renders as Left(x)', function() {
+          expect(leftString.toString()).toBe('Left(error dude)')
         })
 
     })

--- a/test/list-spec.js
+++ b/test/list-spec.js
@@ -195,6 +195,9 @@ describe("An immutable list", function () {
 
             })
         })
+        it('will render as List(x1, x2, x3)', function () {
+          expect(List.fromArray([1, false, 'xyz']).inspect()).toBe('List(1, false, xyz)')
+        })
     })
     describe("that is empty", function () {
         it("will return Nil on tail()", function () {
@@ -208,6 +211,9 @@ describe("An immutable list", function () {
         })
         it("will return an empty list on filter", function() {
           expect(Nil.filter(function() {return true})).toEqual(Nil)
+        })
+        it('will render as Nil', function () {
+            expect(Nil.inspect()).toBe('Nil')
         })
     })
 

--- a/test/maybe-spec.js
+++ b/test/maybe-spec.js
@@ -78,6 +78,9 @@ describe('A Maybe', function () {
           expect(someString.equals(Some('abcd'))).toBeTruthy()
           expect(someString.equals(None())).toBeFalsy()
         })
+        it('will render as Just(x)', function() {
+            expect(someString.inspect()).toBe('Just(abcd)')
+        })
     })
 
     describe('without a value', function () {
@@ -124,10 +127,12 @@ describe('A Maybe', function () {
             expect(none.cata(function() {return 'efg'}, 
                 function(val){ return 'hij'})).toBe('efg')
         })
-
         it('will compare for equality', function() {
           expect(none.equals(Maybe.None())).toBeTruthy()
           expect(none.equals(Maybe.Just(1))).toBeFalsy()
+        })
+        it('will render as Nothing', function() {
+            expect(none.inspect()).toBe('Nothing')
         })
     })
 

--- a/test/nel-spec.js
+++ b/test/nel-spec.js
@@ -107,6 +107,8 @@ describe("A Non-Empty immutable list", function () {
     expect(NEL(1, Nil).reduceLeft(plus)).toEqual(1)
   })
 
-
+  it("will render as NEL(x1, x2, x3)", function () {
+    expect(NEL(1, NEL(false, Nil)).inspect()).toBe('NEL(1, false)')
+  })
 })
 

--- a/test/validation-spec.js
+++ b/test/validation-spec.js
@@ -70,7 +70,9 @@ describe('A Validation', function () {
                 throw "fail"
             }, successMap)).toBeSuccessWith("success abcd")
         })
-
+        it('will render as Success(x)', function () {
+          expect(successString.inspect()).toBe('Success(abcd)')
+        })
     })
 
     var failString = Validation.fail("error dude")
@@ -124,6 +126,9 @@ describe('A Validation', function () {
 
         it('can be failMapped', function() {
             expect(failString.failMap(failMap)).toBeFailureWith("fail: error dude")
+        })
+        it('renders as Fail(x)', function () {
+            expect(failString.inspect()).toBe('Fail(error dude)')
         })
 
     })


### PR DESCRIPTION
Hello,
this change adds inspection methods for container monads, as described in #60.