### PR TITLE
ignore generated files from typings tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ RUNNING_PID
 .settings
 *.swp
 node_modules/
+test/typings/*-spec.js


### PR DESCRIPTION
on my computer the JS files for the typings tests get generated, maybe from the IDE. We want them ignored, better to make it explicit.