### PR TITLE
feat: make applicatives compatible with fantasyland and ramda

### DIFF
--- a/src/monet.js
+++ b/src/monet.js
@@ -1183,6 +1183,9 @@
             type.prototype.concat = type.prototype.append
         }
         type.prototype.point = type.prototype.pure = type.prototype.unit = type.prototype.of
+        if (typeof type.prototype.ap !== 'undefined') {
+            type.prototype['fantasy-land/ap'] = type.prototype.ap
+        }
     }
 
     // Wire up aliases


### PR DESCRIPTION
This pull request makes monet.js applicatives compatible with fantasy-land spec 1.x.y, though making it compatible with next release of ramda. Pull request (https://github.com/ramda/ramda/pull/1900) has been already merged to master to support this. If this pull request gets merged, then monet.js will finally be compatible with ramda (ap, liftN). 

It is already possible to use ramda +monet using ramda-adjunct (https://char0n.github.io/ramda-adjunct/1.3.0/RA.html#.liftFN). ramda-adjunct will keep support the older versions of monet indefinetly.

