### PR TITLE
feat(Identity): add Apply spec

### DIFF
--- a/src/monet.d.ts
+++ b/src/monet.d.ts
@@ -71,6 +71,7 @@ export interface Identity<T> extends IMonad<T> {
   takeLeft(m: Identity<T>): Identity<T>;
   takeRight(m: Identity<T>): Identity<T>;
   contains(val: T): boolean;
+  ap<V>(applyFn: IMonad<(val: T) => V>): IMonad<V>;
 
   /* Identity specific */
   forEach(fn: (val: T) => void): void;

--- a/src/monet.js
+++ b/src/monet.js
@@ -1168,6 +1168,12 @@
         },
         inspect: function () {
             return this.toString()
+        },
+        ap: function (applyWithFunction) {
+            var value = this.val
+            return applyWithFunction.map(function (fn) {
+                return fn(value)
+            })
         }
     }
 


### PR DESCRIPTION
Ref #115 

Used applyFn as IMonad because fantasy land Apply spec doen't say that other type of applicatives are not allowed.

Docs of Identity monad will be part of other PR.